### PR TITLE
fix: express should use react-router for routes

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,4 +1,5 @@
 const express = require('express')
+const path = require('path')
 
 const environment = process.env.ENVIRONMENT
 if(environment !== 'PRODUCTION' && environment !== 'TESTING') {
@@ -9,6 +10,9 @@ if(environment !== 'PRODUCTION' && environment !== 'TESTING') {
 const PROD = environment === 'PRODUCTION'? true : false
 const app = express()
 app.use(express.static('build'))
+app.get('/*', (req, res) => {
+  res.sendFile(path.resolve('', 'build', 'index.html'));
+})
 
 require('greenlock-express').create({
   version: 'draft-11',


### PR DESCRIPTION
Without this, express would try to route when in fact it must delegate that to react-router.