### PR TITLE
fix: pin base-x version

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1326,10 +1326,10 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
-base-x@^3.0.2:
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/base-x/-/base-x-3.0.5.tgz#d3ada59afed05b921ab581ec3112e6444ba0795a"
-  integrity sha512-C3picSgzPSLE+jW3tcBzJoGwitOtazb5B+5YmAxZm2ybmTi9LNgAtDO/jjVEBZwHoXmDBZ9m/IELj3elJVRBcA==
+base-x@3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/base-x/-/base-x-3.0.3.tgz#7870aebb757a49d38d7cf63a6c554c418287cce7"
+  integrity sha512-qKXPTB94LxXhJs8hqwTdyVTiDXMFTRUFj5F7FnWOW19ALCfANf2lHHUnEcY43g3DaVi4X8E2oDCkHIN8bjr32Q==
   dependencies:
     safe-buffer "^5.0.1"
 
@@ -1576,7 +1576,7 @@ bs58@^4.0.1:
   resolved "https://registry.yarnpkg.com/bs58/-/bs58-4.0.1.tgz#be161e76c354f6f788ae4071f63f34e8c4f0a42a"
   integrity sha1-vhYedsNU9veIrkBx9j806MTwpCo=
   dependencies:
-    base-x "^3.0.2"
+    base-x "3.0.3"
 
 bser@1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Due to an update on base-x package (a dependency of bs58, used by eosjs-ecc), all attempts at building projects that use fail. This is an unresolved issue at https://github.com/cryptocoinjs/base-x/issues/51.

As a temporary fix, I've pinned the versions on yarn.lock manually.